### PR TITLE
QOL improvements for Moran

### DIFF
--- a/machines/nixos/moran/default.nix
+++ b/machines/nixos/moran/default.nix
@@ -204,6 +204,7 @@
     playerctl
     blueman
     uutils-coreutils-noprefix
+    yubioath-flutter
   ];
 
   powerManagement = {

--- a/machines/nixos/moran/default.nix
+++ b/machines/nixos/moran/default.nix
@@ -47,6 +47,7 @@
     useNetworkd = true;
   };
   systemd.network = {
+    enable = true;
     wait-online.enable = false;
   };
 

--- a/machines/nixos/moran/default.nix
+++ b/machines/nixos/moran/default.nix
@@ -38,6 +38,11 @@
     useDHCP = false;
     dhcpcd.enable = false;
     wireless.enable = false;
+    
+    useNetworkd = true;
+  };
+  systemd.network = {
+    wait-online.enable = false;
   };
 
   networking.hostName = "moran";
@@ -216,6 +221,7 @@
   nixpkgs.overlays = with inputs; [
     nur.overlays.default
   ];
+
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/machines/nixos/moran/home/default.nix
+++ b/machines/nixos/moran/home/default.nix
@@ -35,6 +35,9 @@
       enable = true;
     };
     ncspot.enable = true;
+    fuzzel = {
+      enable = true;
+    };
   };
 
   programs.ssh = let

--- a/machines/nixos/moran/home/hypr.nix
+++ b/machines/nixos/moran/home/hypr.nix
@@ -84,7 +84,8 @@
       "$terminal" = "ghostty";
       # "$terminal" = "alacritty";
       "$browser" = "firefox";
-      "$menu" = "tofi-drun | xargs hyprctl dispatch exec --";
+      #"$menu" = "tofi-drun | xargs hyprctl dispatch exec --";
+      "$menu" = "fuzzel";
 
       monitor = [
         ", prefered, auto, 1"


### PR DESCRIPTION
This PR enables `networkd` for testing purposes on my laptop and also does the following:

- Add the Yubico Authenticator app (so I can interface with my Yubikey)
- Replace `tofi` with `fuzzel` for app launching

